### PR TITLE
add remove_resource_files_in_output_package to publish config to retain resource files in output package

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -1,6 +1,7 @@
 {
   "need_generate_pdf": false,
   "need_generate_intellisense": false,
+  "remove_resource_files_in_output_package": false,
   "docsets_to_publish": [
     {
       "docset_name": "trustcenter-china",


### PR DESCRIPTION
Add remove_resource_files_in_output_package (false) to publish config to retain resource files in output package. (Fix "Build download package does not contain all the files" issue.)